### PR TITLE
Fix typo in CRUD generator factory method

### DIFF
--- a/app/Console/Commands/CrudCommand.php
+++ b/app/Console/Commands/CrudCommand.php
@@ -58,7 +58,7 @@ class CrudCommand extends GeneratorCommand
             // ->buildSearchableTraits()
             ->buildService()
             ->buildRequest()
-            ->buildFatory()
+            ->buildFactory()
             ->buildSeeder()
             ->buildRoute()
             ->buildTraits()
@@ -248,11 +248,12 @@ class CrudCommand extends GeneratorCommand
     }
 
     /**
+     * Build a new factory for the generated model.
+     *
      * @return $this
      * @throws \Illuminate\Contracts\Filesystem\FileNotFoundException
-     *
      */
-    protected function buildFatory()
+    protected function buildFactory()
     {
         // $factoryPath = $this->_getFactoryPath($this->name);
 


### PR DESCRIPTION
## Summary
- rename `buildFatory` to `buildFactory`
- update invocation in CRUD generation chain
- clarify phpdoc for the factory method

## Testing
- `./vendor/bin/pest` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6840ec2b68648330b0c42809f96e9caa