### PR TITLE
Fix Tenanteble trait boot method

### DIFF
--- a/app/Traits/TenantebleTrait.php
+++ b/app/Traits/TenantebleTrait.php
@@ -7,9 +7,8 @@ use App\Models\Scopes\TenantScope;
 
 trait TenantebleTrait
 {
-    protected static function boot()
+    protected static function bootTenantebleTrait()
     {
-        parent::boot();
         static::addGlobalScope(new TenantScope);
         static::creating(function ($model) {
             if (checkTenantId()) {


### PR DESCRIPTION
## Summary
- rename `boot()` to `bootTenantebleTrait()`
- rely on automatic trait booting

## Testing
- `./vendor/bin/pest` *(fails: database missing migrations)*
- `php artisan migrate --force` *(fails: could not find driver / duplicate columns)*

------
https://chatgpt.com/codex/tasks/task_e_6840edff9b68833088761a182866d97d