### PR TITLE
Fix typo in helpers comment

### DIFF
--- a/app/Helpers/helpers.php
+++ b/app/Helpers/helpers.php
@@ -36,7 +36,7 @@ function formataNumeroBr($numero, $dec = 2)
   return number_format($numero, $dec, ',', '.');
 }
 
-//função limata caracteres
+// função limita caracteres
 function limita_caracteres($texto, $limite, $quebra = true)
 {
   $tamanho = strlen($texto);


### PR DESCRIPTION
## Summary
- fix typo in `limita_caracteres` comment

## Testing
- `php artisan test` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840f20f9c98833082c5e1ed996d0be1