### PR TITLE
Add status steps management link

### DIFF
--- a/app/Http/Controllers/SoStatusStepController.php
+++ b/app/Http/Controllers/SoStatusStepController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Models\SoStatusStep;
+use App\Models\SoStatus;
 use Illuminate\Http\Request;
 use App\Http\Requests\SoStatusStepRequest;
 use App\Http\Requests\PhoneRequest;
@@ -65,8 +66,16 @@ class SoStatusStepController extends Controller
   {
     $this->authorize('soStatusStep listar');
 
-    try {
+        try {
             $query = SoStatusStep::query();
+
+            $status = null;
+
+            if ($request->filled('so_status_id')) {
+                $query->where('so_status_id', $request->get('so_status_id'));
+                $status = SoStatus::find($request->get('so_status_id'));
+            }
+
             $fields = SoStatusStep::getSearchable();
             $query = $this->service->applyFilters($query, $request, $fields);
             $data = $query->paginate($request->get('limit', 10));
@@ -82,6 +91,9 @@ class SoStatusStepController extends Controller
                     ['title' => $this->pageTitle, 'disabled' => true],
                 ],
                 'soStatusStepCount' => $this->service->count(),
+                'data' => $data,
+                'statusId' => $request->get('so_status_id'),
+                'status' => $status,
             ]);
         } catch (\Exception $e) {
             if ($request->wantsJson()) {

--- a/app/Models/SoStatus.php
+++ b/app/Models/SoStatus.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use App\Traits\SoStatusTrait;
+use App\Models\SoStatusStep;
 use Illuminate\Database\Eloquent\Model;
 
 /**
@@ -43,4 +44,12 @@ class SoStatus extends Model
     protected $searchable = [
         'description'
     ];
+
+    /**
+     * Get the steps associated with the status.
+     */
+    public function steps()
+    {
+        return $this->hasMany(SoStatusStep::class, 'so_status_id');
+    }
 }

--- a/resources/js/Pages/ServicesOrder/Statuses/Index.vue
+++ b/resources/js/Pages/ServicesOrder/Statuses/Index.vue
@@ -96,6 +96,10 @@ function deleteItem(item) {
     swToast('Você não tem permissão para excluir status.', 'error', 3000)
   }
 }
+
+function manageSteps(id) {
+  router.get(route('orders.soStatus.steps', id))
+}
 </script>
 
 <template layout="AppShell,AuthenticatedLayout">
@@ -141,6 +145,9 @@ function deleteItem(item) {
             >
               <template #loading>
                 <v-skeleton-loader type="table-row@5" />
+              </template>
+              <template #item.description="{ item }">
+                <a @click.prevent="manageSteps(item.id)" href="#">{{ item.description }}</a>
               </template>
               <template #item.status_type="{ item }">
                 {{ item.status_type == 0 ? 'Entrada' : item.status_type == 1 ? 'Em Andamento' : 'Saida' }}

--- a/resources/js/Pages/SoStatusStep/Index.vue
+++ b/resources/js/Pages/SoStatusStep/Index.vue
@@ -4,6 +4,14 @@ import { router } from '@inertiajs/vue3'
 const props = defineProps({
   data: {
     type: Object
+  },
+  statusId: {
+    type: [Number, String],
+    default: null
+  },
+  status: {
+    type: Object,
+    default: null
   }
 })
 
@@ -16,10 +24,10 @@ const pageCount = computed(() => {
 })
 const headers = ref([
   { title: 'ID', key: 'id' },
-	{ title: 'Tenant Id', key: 'tenant_id' },
-	{ title: 'So Status Id', key: 'so_status_id' },
-	{ title: 'Description', key: 'description' },
-  { title: 'Action', key: 'action', sortable: false, align: 'end' },
+  { title: 'Tenant Id', key: 'tenant_id' },
+  { title: 'So Status Id', key: 'so_status_id' },
+  { title: 'Description', key: 'description' },
+  { title: 'Action', key: 'action', sortable: false, align: 'end' }
 ])
 
 function loadItems({ page, itemsPerPage, sortBy, search }) {
@@ -32,6 +40,9 @@ function loadItems({ page, itemsPerPage, sortBy, search }) {
   }
   if (search) {
     params.search = search
+  }
+  if (props.statusId) {
+    params.so_status_id = props.statusId
   }
   router.get('/so-status-steps', params, {
     preserveState: true,
@@ -80,7 +91,7 @@ onMounted(() => {
 </script>
 
 <template layout="AppShell,AuthenticatedLayout">
-  <v-card class="mx-auto" width="800" prepend-icon="mdi-account-lock" :title="$page.props.title">
+  <v-card class="mx-auto" width="800" prepend-icon="mdi-account-lock" :title="props.status ? `Etapas de ${props.status.description}` : $page.props.title">
     <template #append>
       <v-btn prepend-icon="mdi-plus" color="primary" variant="text" @click="createItem()">Novo</v-btn>
     </template>

--- a/routes/web.php
+++ b/routes/web.php
@@ -156,6 +156,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
             Route::get('/{id}/edit', 'edit')->name('edit');
             Route::put('/{id}', 'update')->name('update');
             Route::delete('/{id}', 'destroy')->name('destroy');
+            Route::get('/{id}/steps', [SoStatusStepController::class, 'index'])->name('steps');
         });
         // Route groups for SoStatusStep
     Route::controller(SoStatusStepController::class)->prefix('so-status-steps')->as('soStatusStep.')->group(function () {


### PR DESCRIPTION
## Summary
- define relation between status and its steps
- filter steps by status in controller and include data
- expose route `orders.soStatus.steps`
- add link to manage steps in statuses list
- show status description on steps index when filtered

## Testing
- `npm run lint` *(fails: Invalid option '--ignore-path')*
- `npm run format`
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68449dcfe87c8330b8dbb201d46834ce